### PR TITLE
licence + python 3.7/3.8 + rm sunpy-soar

### DIFF
--- a/PHI_tutorial/LICENCE
+++ b/PHI_tutorial/LICENCE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Jonas Sinjan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/PHI_tutorial/LICENCE
+++ b/PHI_tutorial/LICENCE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Jonas Sinjan
+Copyright (c) 2022 Max Planck Institute for Solar System Research
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/PHI_tutorial/requirements.txt
+++ b/PHI_tutorial/requirements.txt
@@ -2,6 +2,5 @@ sunpy==3.1.0
 numpy==1.19.2
 scipy==1.6.2
 astropy==4.3.1
-sunpy-soar==1.4
 matplotlib==3.3.2
 python>=3.7.0

--- a/PHI_tutorial/requirements.txt
+++ b/PHI_tutorial/requirements.txt
@@ -1,7 +1,7 @@
-sunpy>=3.0.0
-numpy
-scipy
-astropy>=4.0.0
-sunpy-soar
-matplotlib
-reproject
+sunpy==3.1.0
+numpy==1.19.2
+scipy==1.6.2
+astropy==4.3.1
+sunpy-soar==1.4
+matplotlib==3.3.2
+python>=3.7.0


### PR DESCRIPTION
-jupyter notebook was tested with python 3.7 and 3.8.12 (requiremnts updated)
-MIT licence added
-sunpy soar search removed